### PR TITLE
Fixes bug with New Messages

### DIFF
--- a/app/renderer/components/chat/Messages.tsx
+++ b/app/renderer/components/chat/Messages.tsx
@@ -45,7 +45,7 @@ export class Messages extends Component<IProps, IState> {
   }
 
   private isScrolledToBottom(): boolean {
-    return !!(this.list && Math.trunc(this.list.scrollTop) === Math.trunc(this.scrollBottom))
+    return !!(this.list && Math.round(this.list.scrollTop) === Math.round(this.scrollBottom))
   }
 
   scrollToBottom(): void {


### PR DESCRIPTION
When using Metastream on my laptop (this did not occur on my desktop) I encountered an issue where whenever I would queue new media the "New Messages" alert would show up at the bottom of my chat box and wouldn't go away even if I had seen all the new messages and scrolled the chat to the very bottom. This would also prevent the chat from automatically scrolling down when new messages come in and was very frustrating. So I decided to try and fix it. I found that in the function isScrolledToBottom this.list.scrollTop and this.scrollBottom are truncated and checked if they are equal. The problem seemed to arise because this.list.scrollTop had the value 69.555556 (approx) and this.scrollBottom has the value of 70. When the former is truncated it becomes 69 and thus is not equal to the latter value of 70. I figured this could be fixed by rounding the values as opposed to truncating them.

I hope this is helpful. I would love to contribute more to this project if it is okay. 😄 