### PR TITLE
Add logic for retry button shown on disconnect.

### DIFF
--- a/packages/metastream-app/src/components/lobby/Disconnect.css
+++ b/packages/metastream-app/src/components/lobby/Disconnect.css
@@ -24,3 +24,7 @@
 .titlebar {
   composes: titlebar from '../GameLobby.css';
 }
+
+.buttonrow > *:not(:last-child) {
+  margin-right: 5px;
+}

--- a/packages/metastream-app/src/components/lobby/Disconnect.tsx
+++ b/packages/metastream-app/src/components/lobby/Disconnect.tsx
@@ -9,8 +9,8 @@ import { ExternalLink } from '../common/link'
 import { Trans, withNamespaces, WithNamespaces } from 'react-i18next'
 
 interface IProps extends WithNamespaces {
-  reason: NetworkDisconnectReason,
-  reconnect: () => void,
+  reason: NetworkDisconnectReason
+  reconnect: () => void
 }
 
 class _Disconnect extends Component<IProps> {
@@ -37,10 +37,12 @@ class _Disconnect extends Component<IProps> {
             )}
           </span>
         </p>
-        <Link to="/">
-          <MenuButton size="medium">{t('ok')}</MenuButton>
-        </Link>
-        <MenuButton size="medium" onClick={reconnect}>{t('retry')}</MenuButton>
+        <div className={styles.buttonrow}>
+          <Link to="/">
+            <MenuButton size="medium">{t('ok')}</MenuButton>
+          </Link>
+          <MenuButton size="medium" onClick={reconnect}>{t('retry')}</MenuButton>
+        </div>
       </div>
     )
   }

--- a/packages/metastream-app/src/components/lobby/Disconnect.tsx
+++ b/packages/metastream-app/src/components/lobby/Disconnect.tsx
@@ -9,12 +9,13 @@ import { ExternalLink } from '../common/link'
 import { Trans, withNamespaces, WithNamespaces } from 'react-i18next'
 
 interface IProps extends WithNamespaces {
-  reason: NetworkDisconnectReason
+  reason: NetworkDisconnectReason,
+  reconnect: () => void,
 }
 
 class _Disconnect extends Component<IProps> {
   render(): JSX.Element {
-    const { t, reason } = this.props
+    const { t, reason, reconnect } = this.props
     const reasonKey: any = NetworkDisconnectMessages[reason]
     const msg = t(reasonKey) || reasonKey
 
@@ -39,6 +40,7 @@ class _Disconnect extends Component<IProps> {
         <Link to="/">
           <MenuButton size="medium">{t('ok')}</MenuButton>
         </Link>
+        <MenuButton size="medium" onClick={reconnect}>{t('retry')}</MenuButton>
       </div>
     )
   }

--- a/packages/metastream-app/src/containers/LobbyPage.tsx
+++ b/packages/metastream-app/src/containers/LobbyPage.tsx
@@ -181,7 +181,8 @@ export class _LobbyPage extends Component<PrivateProps, IState> {
   }
 
   private reconnect = () => {
-    this.setupLobby();
+    this.setState({ disconnectReason: undefined })
+    this.setupLobby()
   }
 
   private onLoadScreen() {
@@ -257,9 +258,7 @@ export class _LobbyPage extends Component<PrivateProps, IState> {
 
   render(): JSX.Element {
     if (this.state.disconnectReason) {
-      return <Disconnect
-        reason={this.state.disconnectReason}
-        reconnect={this.reconnect} />
+      return <Disconnect reason={this.state.disconnectReason} reconnect={this.reconnect} />
     }
 
     if (!this.host && !(this.state.connected && this.props.clientAuthorized)) {

--- a/packages/metastream-app/src/containers/LobbyPage.tsx
+++ b/packages/metastream-app/src/containers/LobbyPage.tsx
@@ -180,6 +180,10 @@ export class _LobbyPage extends Component<PrivateProps, IState> {
     this.disconnect(reason, true)
   }
 
+  private reconnect = () => {
+    this.setupLobby();
+  }
+
   private onLoadScreen() {
     this.host = this.props.match.params.lobbyId === localUserId()
     this.props.dispatch(initLobby({ host: this.host }))
@@ -253,7 +257,9 @@ export class _LobbyPage extends Component<PrivateProps, IState> {
 
   render(): JSX.Element {
     if (this.state.disconnectReason) {
-      return <Disconnect reason={this.state.disconnectReason} />
+      return <Disconnect
+        reason={this.state.disconnectReason}
+        reconnect={this.reconnect} />
     }
 
     if (!this.host && !(this.state.connected && this.props.clientAuthorized)) {

--- a/packages/metastream-app/src/locale/en-US.ts
+++ b/packages/metastream-app/src/locale/en-US.ts
@@ -73,6 +73,7 @@ export default {
   reload: 'Reload',
   remove: 'Remove',
   repeat: 'Repeat',
+  retry: 'Retry',
   requestUrl: 'Add to session',
   requestUrlPlaceholder: '',
   requiresDJPermissions: 'Requires DJ permissions',


### PR DESCRIPTION
- [x] Test that the `reconnect` logic works and the UI updates as it should
- [x] ~~Disable the button on click for a few seconds to prevent spam clicking~~
- [x] Display `OK` and `Retry` buttons inline w/ padding (see below)

<img src="https://user-images.githubusercontent.com/38229097/58390980-b6c7b080-802b-11e9-81b8-0caca49fc525.png " width="512">