### PR TITLE
Fix minor MenuButton graphical issue in Firefox. 

### DIFF
--- a/packages/metastream-app/src/components/menu/MenuButton.css
+++ b/packages/metastream-app/src/components/menu/MenuButton.css
@@ -18,16 +18,17 @@
 }
 
 .btn *:not(svg) {
-  mix-blend-mode: soft-light;
   color: black;
   vertical-align: middle;
 }
 
 .btn span {
+  mix-blend-mode: soft-light;
   text-decoration: none;
 }
 
 .btn svg {
+  mix-blend-mode: soft-light;
   margin-right: 14px;
 }
 


### PR DESCRIPTION
Fixes #116. The MenuButtons appear the same way as in Chromium with this fix.